### PR TITLE
forced target system type for libid3tag and libmad configure

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ wget https://netix.dl.sourceforge.net/project/mad/libid3tag/0.15.1b/libid3tag-0.
 tar xzf libid3tag-0.15.1b.tar.gz
 cd libid3tag-0.15.1b
 sed -i 's/ -fforce-mem//' configure
-./configure --disable-shared --prefix=/usr --libdir=/usr/lib64
+./configure --disable-shared --prefix=/usr --libdir=/usr/lib64  --build=aarch64-unknown-linux-gnu
 make install
 
 # Build libmad
@@ -17,7 +17,7 @@ wget https://netix.dl.sourceforge.net/project/mad/libmad/0.15.1b/libmad-0.15.1b.
 tar xzf libmad-0.15.1b.tar.gz
 cd libmad-0.15.1b
 sed -i 's/ -fforce-mem//' configure
-./configure --disable-shared --prefix=/usr --libdir=/usr/lib64
+./configure --disable-shared --prefix=/usr --libdir=/usr/lib64 --build=aarch64-unknown-linux-gnu
 make install
 
 # Build libogg


### PR DESCRIPTION
I followed the instructions to build the bin using the docker but compilation failed since in 2 cases the configure was unable to guess the target system type.  My host is an Apple M1 Pro with MacOS Ventura 13.0 but I don't think this is the cause of the issue.  Probably that happens since Dockerfile contains "FROM amazonlinux:2" and since this code was released several updates on that images were released.

I've forced libid3tag and libmad not to guess the target system adding "--build=aarch64-unknown-linux-gnu"

**N.B.** I've just tested it on my above environment, if you can test it on some different hosts please.

This is the error I got without this PR:

```
2022-11-03 12:43:12 (1.15 MB/s) - 'libid3tag-0.15.1b.tar.gz' saved [338143/338143]

+ tar xzf libid3tag-0.15.1b.tar.gz
+ cd libid3tag-0.15.1b
+ sed -i 's/ -fforce-mem//' configure
+ ./configure --disable-shared --prefix=/usr --libdir=/usr/lib64
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
checking build system type... ./config.guess: unable to guess system type

This script, last modified 2004-01-05, has failed to recognize
the operating system you are using. It is advised that you
download the most up to date version of the config scripts from

    ftp://ftp.gnu.org/pub/gnu/config/

If the version you run (./config.guess) is already up to date, please
send the following data and any information you think might be
pertinent to <config-patches@gnu.org> in order to provide the needed
information to handle your system.

config.guess timestamp = 2004-01-05

uname -m = aarch64
uname -r = 5.10.124-linuxkit
uname -s = Linux
uname -v = #1 SMP PREEMPT Thu Jun 30 08:18:26 UTC 2022

/usr/bin/uname -p = aarch64
/bin/uname -X     =

hostinfo               =
/bin/universe          =
/usr/bin/arch -k       =
/bin/arch              = aarch64
/usr/bin/oslevel       =
/usr/convex/getsysinfo =

UNAME_MACHINE = aarch64
UNAME_RELEASE = 5.10.124-linuxkit
UNAME_SYSTEM  = Linux
UNAME_VERSION = #1 SMP PREEMPT Thu Jun 30 08:18:26 UTC 2022
configure: error: cannot guess build type; you must specify one
```